### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/201/339/421201339.geojson
+++ b/data/421/201/339/421201339.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Spanish Town"
+    ],
+    "name:deu_x_preferred":[
+        "Spanish Town"
+    ],
     "name:eng_x_preferred":[
         "Spanish Town"
     ],
@@ -24,6 +30,9 @@
         "Spanish Town"
     ],
     "name:hun_x_preferred":[
+        "Spanish Town"
+    ],
+    "name:ita_x_preferred":[
         "Spanish Town"
     ],
     "name:jpn_x_preferred":[
@@ -43,6 +52,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0633\u067e\u06cc\u0646\u0634 \u0679\u0627\u0624\u0646"
+    ],
+    "name:zho_x_preferred":[
+        "\u897f\u73ed\u7259\u9547"
     ],
     "qs:gn_country":"VG",
     "qs:gn_fcode":"PPL",
@@ -94,7 +106,7 @@
         }
     ],
     "wof:id":421201339,
-    "wof:lastmodified":1636505985,
+    "wof:lastmodified":1690921362,
     "wof:name":"Spanish Town",
     "wof:parent_id":85681419,
     "wof:placetype":"locality",

--- a/data/890/434/937/890434937.geojson
+++ b/data/890/434/937/890434937.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0631\u0648\u062f \u062a\u0627\u0648\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Road Town"
+    ],
+    "name:arz_x_preferred":[
+        "\u0631\u0648\u062f \u062a\u0627\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Road Town"
     ],
@@ -33,6 +39,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0420\u043e\u0434-\u0422\u0430\u045e\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0420\u043e\u0434-\u0422\u0430\u045e\u043d"
     ],
     "name:bos_x_preferred":[
         "Road Town"
@@ -82,6 +91,9 @@
     "name:fra_x_preferred":[
         "Road Town"
     ],
+    "name:gle_x_preferred":[
+        "Road Town"
+    ],
     "name:glg_x_preferred":[
         "Road Town"
     ],
@@ -91,6 +103,9 @@
     "name:hrv_x_preferred":[
         "Road Town"
     ],
+    "name:hun_x_preferred":[
+        "Road Town"
+    ],
     "name:hye_x_preferred":[
         "\u054c\u0578\u0564 \u0539\u0561\u0578\u0582\u0576"
     ],
@@ -98,6 +113,9 @@
         "Road Town"
     ],
     "name:ind_x_preferred":[
+        "Road Town"
+    ],
+    "name:isl_x_preferred":[
         "Road Town"
     ],
     "name:ita_x_preferred":[
@@ -120,6 +138,9 @@
     ],
     "name:lit_x_preferred":[
         "Rod Taunas"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0420\u043e\u0443\u0434 \u0422\u0430\u0443\u043d"
     ],
     "name:nan_x_preferred":[
         "Road Town"
@@ -169,6 +190,12 @@
     "name:tam_x_preferred":[
         "\u0bb0\u0bcb\u0b9f\u0bc1 \u0b9f\u0bb5\u0bc1\u0ba9\u0bcd"
     ],
+    "name:tha_x_preferred":[
+        "\u0e42\u0e23\u0e14\u0e17\u0e32\u0e27\u0e19\u0e4c"
+    ],
+    "name:tum_x_preferred":[
+        "Road Town"
+    ],
     "name:tur_x_preferred":[
         "Road Town"
     ],
@@ -183,6 +210,9 @@
     ],
     "name:war_x_preferred":[
         "Road Town"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7f57\u5fb7\u57ce"
     ],
     "name:yor_x_preferred":[
         "Road Town"
@@ -226,7 +256,7 @@
         }
     ],
     "wof:id":890434937,
-    "wof:lastmodified":1566647163,
+    "wof:lastmodified":1690921362,
     "wof:name":"Road Town",
     "wof:parent_id":85681419,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.